### PR TITLE
Process metadata

### DIFF
--- a/test_table.tsv
+++ b/test_table.tsv
@@ -1,0 +1,6 @@
+entity:sample_id	county	date_collected	median_coverage	mean_coverge
+foo	SF			5
+bar	['']	2025-01-01	5	5
+bizz	Lake	2025-01-02	9	8.5
+buzz			
+zip	LA	''	20	[]

--- a/test_table.tsv
+++ b/test_table.tsv
@@ -1,6 +1,11 @@
-entity:sample_id	county	date_collected	median_coverage	mean_coverge
-foo	SF			5
-bar	['']	2025-01-01	5	5
-bizz	Lake	2025-01-02	9	8.5
-buzz			
-zip	LA	''	20	[]
+entity:INSTI_id	county	date_collected	median_coverage	mean_coverge	notes
+SAMEA11961644	SF			5	passing
+SAMEA9977641	['']	2025-01-01	5	5	passing
+SAMEA6875586	Lake	2025-01-02	9	8.5	passing
+SAMN16521767					passing
+SAMEA4846676	LA	''	20	[]	passing
+foo	SF			5	failing
+bar	['']	2025-01-01	5	5	failing
+bizz	Lake	2025-01-02	9	8.5	failing
+buzz					failing
+fizz	LA	''	20	[]	failing

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -37,6 +37,8 @@ task make_mask_and_diff_and_process_metadata {
 		String? d_value
 		String? e_key
 		String? e_value
+		String? f_key
+		String? f_value
 
 		# runtime attributes
 		Int addldisk = 10
@@ -133,20 +135,18 @@ task make_mask_and_diff_and_process_metadata {
 					rm "~{basename_vcf}.diff"
 				fi
 				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
-				echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
+				echo FAILURE - "$pretty_percent""%" is above "~{min_coverage_per_site}""%" cutoff
 				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE_"("MAX_"$maximium_percent_low_coverage"_PCT")" >> ERROR
 
 				end=$(date +%s)
 				seconds=$(echo "$end - $start" | bc)
 				minutes=$(echo "$seconds" / 60 | bc)
-				echo "Finished in about $minutes minutes ($seconds sec))"
-				ls -lha
-				exit 0
+				echo "Finished in about $minutes minutes ($seconds sec)) -- although we QC failed, we'll still write metadata"
 			fi
 		fi
 	fi
 
-	# this section only exectures if not failing
+	# this executes even if a sample is failing
 	python3 << CODE
 	a_key =  "~{a_key}"
 	a_value = "~{a_value}"
@@ -158,25 +158,28 @@ task make_mask_and_diff_and_process_metadata {
 	d_value = "~{d_value}"
 	e_key =  "~{e_key}"
 	e_value = "~{e_value}"
+	f_key = "~{f_key}"
+	f_value = "~{f_value}"
+
+	with open('ERROR') as f:
+		status = f.readline()
 
 	valid_keys = []
-	for key in [a_key, b_key, c_key, d_key, e_key]:
-		print(key)
+	for key in [a_key, b_key, c_key, d_key, e_key, f_key]:
 		if key == '' or key == ' ' or key == "'":
 			print(f"key [{key}] effectively is undefined")
 			key = "UNDEFINED"
 		print(f"adding {key} to valid_keys")
 		valid_keys.append(key.strip("'").strip('"'))
-		print(f"valid_keys: {valid_keys}")
+	print(f"valid_keys: {valid_keys}")
 	valid_values = []
-	for value in [a_value, b_value, c_value, d_value, e_value]:
-		print(value)
+	for value in [a_value, b_value, c_value, d_value, e_value, f_value]:
 		if value == '' or value == ' ' or value == "'":
 			print(f"value [{value}] effectively is undefined")
 			value = "UNDEFINED"
 		print(f"adding {value} to valid_values")
 		valid_values.append(value.strip("'").strip('"'))
-		print(f"valid_values: {valid_values}")
+	print(f"valid_values: {valid_values}")
 
 	assert len(valid_keys) == len(valid_values)
 	metadata_dict = dict(zip(valid_keys, valid_values))
@@ -194,12 +197,22 @@ task make_mask_and_diff_and_process_metadata {
 			valid_metadata_dict[keys] = values
 	
 	# turn this into something WDL can use
-	header = "sample\t" + "\t".join(valid_metadata_dict.keys())
-	body = "~{basename_vcf}\t" + "\t".join(valid_metadata_dict.values())
-	with open('header.txt', 'w') as f:
-		f.write(header)
-	with open('body.txt', 'w') as f:
-		f.write(body)
+	# for maximum compatibility, we're going to try tabs AND commas
+	
+	header_tsv = "sample\tstatus\t" + "\t".join(valid_metadata_dict.keys())
+	body_tsv = f"~{basename_vcf}\t{status}\t" + "\t".join(valid_metadata_dict.values())
+	metadata_tsv = header_tsv + "\n" + body_tsv
+	header_tsv, body_tsv, metadata_tsv = header_tsv[:-1], body_tsv[:-1], metadata_tsv[:-1]
+
+	header_csv = "sample,status," + ",".join(valid_metadata_dict.keys())
+	body_csv = f"~{basename_vcf},{status}," + ",".join(valid_metadata_dict.values())
+	metadata_csv = header_csv + "\n" + body_csv
+	header_csv, body_csv, metadata_csv = header_csv[:-1], body_csv[:-1], metadata_csv[:-1]
+
+	for string, file in {header_tsv: "header.tsv", body_tsv: "body.tsv", metadata_tsv: "metadata.tsv", header_csv: "header.csv", body_csv: "body.csv", metadata_csv: "metadata.csv"}.items():
+		with open(file, 'w') as f:
+			f.write(string)
+
 	CODE
 
 	# how long did this take?
@@ -228,8 +241,12 @@ task make_mask_and_diff_and_process_metadata {
 		File? diff = basename_vcf+".diff"
 		File? report = basename_vcf+".report"
 		File? histogram = "histogram.txt"
-		String? metadata_fields = read_string("header.txt") #!UnnecessaryQuantifier
-		String? metadata_values = read_string("body.txt")   #!UnnecessaryQuantifier
+		String meta_header_tsv = read_string("header.tsv")
+		String meta_header_csv = read_string("header.csv")
+		String meta_values_tsv = read_string("body.tsv")
+		String meta_values_csv = read_string("body.csv")
+		String meta_full_tsv = read_string("metadata.tsv")
+		String meta_full_csv = read_string("metadata.csv")
 		String errorcode = read_string("ERROR")
 	}
 }

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -162,7 +162,7 @@ task make_mask_and_diff_and_process_metadata {
 	valid_keys = []
 	for key in [a_key, b_key, c_key, d_key, e_key]:
 		print(key)
-		if key == '' or key == ' ':
+		if key == '' or key == ' ' or key == "'":
 			print(f"key [{key}] effectively is undefined")
 			key = "UNDEFINED"
 		print(f"adding {key} to valid_keys")
@@ -171,14 +171,15 @@ task make_mask_and_diff_and_process_metadata {
 	valid_values = []
 	for value in [a_value, b_value, c_value, d_value, e_value]:
 		print(value)
-		if value == '' or value == ' ':
+		if value == '' or value == ' ' or value == "'":
 			print(f"value [{value}] effectively is undefined")
 			value = "UNDEFINED"
 		print(f"adding {value} to valid_values")
 		valid_values.append(value.strip("'").strip('"'))
 		print(f"valid_values: {valid_values}")
 
-	metadata_dict = {a_key: a_value, b_key: b_value, c_key: c_value, d_key: d_value, e_key: e_value}
+	assert len(valid_keys) == len(valid_values)
+	metadata_dict = dict(zip(valid_keys, valid_values))
 	valid_metadata_dict = dict()
 	for keys, values in metadata_dict.items():
 		if keys == "UNDEFINED" and values == "UNDEFINED":

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -100,28 +100,29 @@ task make_mask_and_diff_and_process_metadata {
 		then
 			echo "Scientific notation detected, so it's likely this sample is very much passing."
 			echo "PASS" >> ERROR
-			exit 0
-		fi
 		
-		percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
-		echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
-		
-		# piping an inequality to `bc` will return 0 if false, 1 if true
-		is_bigger=$(echo "$amount_low_coverage>~{max_ratio_low_coverage_sites_per_sample}" | bc)
-		if [[ $is_bigger == 0 ]]
-		then
-			# amount of low coverage is BELOW the removal threshold: sample passes
-			echo "PASS" >> ERROR
-	
+		# not using scientific notation
 		else
-			# amount of low coverage is ABOVE the removal threshold: sample fails
-			if [[ "~{force_diff}" == "false" ]]
+			percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
+			echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
+			
+			# piping an inequality to `bc` will return 0 if false, 1 if true
+			is_bigger=$(echo "$amount_low_coverage>~{max_ratio_low_coverage_sites_per_sample}" | bc)
+			if [[ $is_bigger == 0 ]]
 			then
-				rm "~{basename_vcf}.diff"
+				# amount of low coverage is BELOW the removal threshold: sample passes
+				echo "PASS" >> ERROR
+		
+			else
+				# amount of low coverage is ABOVE the removal threshold: sample fails
+				if [[ "~{force_diff}" == "false" ]]
+				then
+					rm "~{basename_vcf}.diff"
+				fi
+				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
+				echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
+				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
 			fi
-			pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
-			echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
-			echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
 		fi
 	fi
 			

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -167,8 +167,8 @@ task make_mask_and_diff_and_process_metadata {
 	valid_values = []
 	for value in [a_value, b_value, c_value, d_value, e_value]:
 		if value == '' or value == ' ':
-				value = "UNDEFINED"
-			valid_values.append(value.strip("'").strip('"'))
+			value = "UNDEFINED"
+		valid_values.append(value.strip("'").strip('"'))
 
 	metadata_dict = {a_key: a_value, b_key: b_value, c_key: c_value, d_key: d_value, e_key: e_value}
 	valid_metadata_dict = dict()

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -115,8 +115,6 @@ task make_mask_and_diff_and_process_metadata {
 		then
 			echo "Scientific notation detected, so it's likely this sample is very much passing."
 			echo "PASS" >> ERROR
-		
-		# not using scientific notation
 		else
 			percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
 			maximium_percent_low_coverage=$(echo "~{max_ratio_low_coverage_sites_per_sample}*100" | bc)
@@ -128,7 +126,6 @@ task make_mask_and_diff_and_process_metadata {
 			then
 				# amount of low coverage is BELOW the removal threshold: sample passes
 				echo "PASS" >> ERROR
-		
 			else
 				# amount of low coverage is ABOVE the removal threshold: sample fails
 				if [[ "~{force_diff}" == "false" ]]
@@ -137,7 +134,7 @@ task make_mask_and_diff_and_process_metadata {
 				fi
 				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
 				echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
-				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE_(MAX_"~{maximium_percent_low_coverage}"_PCT) >> ERROR
+				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE_"("MAX_"$maximium_percent_low_coverage"_PCT")" >> ERROR
 
 				end=$(date +%s)
 				seconds=$(echo "$end - $start" | bc)
@@ -150,7 +147,7 @@ task make_mask_and_diff_and_process_metadata {
 	fi
 
 	# this section only exectures if not failing
-	python3 CODE <<
+	python3 << CODE
 	a_key =  "~{a_key}"
 	a_value = "~{a_value}"
 	b_key =  "~{b_key}"
@@ -166,12 +163,12 @@ task make_mask_and_diff_and_process_metadata {
 	for key in [a_key, b_key, c_key, d_key, e_key]:
 		if key == '' or key == ' ':
 			key = "UNDEFINED"
-		valid_keys.append(key)
+		valid_keys.append(key.strip("'").strip('"'))
 	valid_values = []
 	for value in [a_value, b_value, c_value, d_value, e_value]:
 		if value == '' or value == ' ':
 				value = "UNDEFINED"
-			valid_values.append(value)
+			valid_values.append(value.strip("'").strip('"'))
 
 	metadata_dict = {a_key: a_value, b_key: b_value, c_key: c_value, d_key: d_value, e_key: e_value}
 	valid_metadata_dict = dict()
@@ -220,8 +217,8 @@ task make_mask_and_diff_and_process_metadata {
 		File? diff = basename_vcf+".diff"
 		File? report = basename_vcf+".report"
 		File? histogram = "histogram.txt"
-		String? metadata_fields = read_string("header.txt")
-		String? metadata_values = read_string("body.txt")
+		String? metadata_fields = read_string("header.txt") #!UnnecessaryQuantifier
+		String? metadata_values = read_string("body.txt")   #!UnnecessaryQuantifier
 		String errorcode = read_string("ERROR")
 	}
 }

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -184,7 +184,7 @@ task make_mask_and_diff_and_process_metadata {
 	
 	# turn this into something WDL can use
 	header = "sample\t" + "\t".join(valid_metadata_dict.keys())
-	body = "~{basename_vcf}.diff\t" + "\t".join(valid_metadata_dict.keys())
+	body = "~{basename_vcf}\t" + "\t".join(valid_metadata_dict.keys())
 	with open('header.txt', 'w') as f:
 		f.write(header)
 	with open('body.txt', 'w') as f:

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -1,5 +1,159 @@
 version 1.0
 
+task make_mask_and_diff_and_process_metadata {
+	# For basic information, see make_mask_and_diff.
+	#
+	# This version additionally processes some metadata fields. If the sample is passing,
+	# these fields will be the sample value they were passed in. If the sample is failing,
+	# these fields will be undefined. This is a workaround for upstream tasks/pipelines
+	# that take in more than one sample at a time and its metadata.
+	#
+	# "Why can't we just write a TSV file?" Because CalTBNet needs to run per-sample due to
+	# how the data table is set up and due to Terra limitations, so this task runs per-sample,
+	# so you'd have one two-line TSV file per sample, and then you'd have to localize all of 
+	# those thousands of TSV files into a downstream task, and then concatenate them.
+	#
+	# I don't love this workaround, but it seems to be the best option for now.
+	input {
+		File bam
+		Boolean force_diff = false
+		Boolean histograms = false
+		Float max_ratio_low_coverage_sites_per_sample # for sra, default was 0.05
+		Int min_coverage_per_site
+		File? tbmf
+		File vcf
+
+		# runtime attributes
+		Int addldisk = 10
+		Int cpu      = 8
+		Int retries  = 1
+		Int memory   = 16
+		Int preempt  = 1
+	}
+	String basename_bam = basename(bam, ".bam")
+	String basename_vcf = basename(vcf, ".vcf")
+	Int finalDiskSize = ceil(size(bam, "GB")*2) + ceil(size(vcf, "GB")*2) + addldisk
+
+	parameter_meta {
+		bam: "BAM file for this sample"
+		force_diff: "Output a diff file even if sample is discarded for being below min_proportion_low_coverage_per_sample"
+		histograms: "Generate histogram output"
+		max_ratio_low_coverage_sites_per_sample: "If over this percent (0.5 = 50%) of a sample's sites get masked due to being below min_coverage_per_site, discard the entire sample"
+		min_coverage_per_site: "Positions with coverage below this value will be masked in diff files"
+		tbmf: "BED file of regions of the genome you always want to mask (default: R00000039_repregions.bed)"
+		vcf: "VCF file for this sample"
+	}
+	
+	command <<<
+	set -eux pipefail
+	start=$(date +%s)
+
+	# We want the mask file the user input, if it exists, to be the mask file, else
+	# fall back on a default mask file that exists in the Docker image already.
+	# We cannot use WDL built-in select_first, or else the user inputting a mask file
+	# will result in WDL looking for the literal gs:// URI rather than while the file
+	# is localized. Different WDL executors localize files to different places, so the
+	# following workaround, while goofy, seems to be the most robust.
+	if [[ "~{tbmf}" = "" ]]
+	then
+		mask="/mask/R00000039_repregions.bed"
+	else
+		mask="~{tbmf}"
+	fi
+	
+	echo "Copying bam..."
+	cp ~{bam} .
+	
+	echo "Sorting bam..."
+	samtools sort -u ~{basename_bam}.bam > sorted_u_~{basename_bam}.bam
+	
+	echo "Calculating coverage..."
+	bedtools genomecov -ibam sorted_u_~{basename_bam}.bam -bga | \
+		awk '$4 < ~{min_coverage_per_site}' > \
+		~{basename_bam}_below_~{min_coverage_per_site}x_coverage.bedgraph
+	
+	if [[ "~{histograms}" = "true" ]]
+	then
+		echo "Generating histograms..."
+		bedtools genomecov -ibam sorted_u_~{basename_bam}.bam > histogram.txt
+	fi
+	
+	echo "Pulling diff script..."
+	wget https://raw.githubusercontent.com/aofarrel/parsevcf/1.3.1/vcf_to_diff_script.py
+	echo "Running script..."
+	python3 vcf_to_diff_script.py -v ~{vcf} \
+	-d . \
+	-tbmf ${mask} \
+	-bed ~{basename_bam}_below_~{min_coverage_per_site}x_coverage.bedgraph \
+	-cd ~{min_coverage_per_site}
+	
+	# if the sample has too many low coverage sites, throw it out
+	this_files_info=$(awk -v file_to_check="~{basename_vcf}.diff" '$1 == file_to_check' "~{basename_vcf}.report")
+	if [[ ! "$this_files_info" = "" ]]
+	then
+		# okay, we have information about this file. is it above the removal threshold?
+		echo "$this_files_info" > temp
+		amount_low_coverage=$(cut -f2 temp)
+		
+		# account for very tiny numbers (very big numbers should be impossible)
+		if [[ "$amount_low_coverage" == *"e"* ]]
+		then
+			echo "Scientific notation detected, so it's likely this sample is very much passing."
+			echo "PASS" >> ERROR
+			exit 0
+		fi
+		
+		percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
+		echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
+		
+		# piping an inequality to `bc` will return 0 if false, 1 if true
+		is_bigger=$(echo "$amount_low_coverage>~{max_ratio_low_coverage_sites_per_sample}" | bc)
+		if [[ $is_bigger == 0 ]]
+		then
+			# amount of low coverage is BELOW the removal threshold: sample passes
+			echo "PASS" >> ERROR
+	
+		else
+			# amount of low coverage is ABOVE the removal threshold: sample fails
+			if [[ "~{force_diff}" == "false" ]]
+			then
+				rm "~{basename_vcf}.diff"
+			fi
+			pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
+			echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
+			echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
+		fi
+	fi
+			
+	end=$(date +%s)
+	seconds=$(echo "$end - $start" | bc)
+	minutes=$(echo "$seconds" / 60 | bc)
+	echo "Finished in about $minutes minutes ($seconds sec))"
+	ls -lha
+	>>>
+
+	runtime {
+		cpu: cpu
+		docker: "ashedpotatoes/sranwrp:1.1.15"
+		disks: "local-disk " + finalDiskSize + " HDD"
+		maxRetries: "${retries}"
+		memory: "${memory} GB"
+		preemptible: "${preempt}"
+	}
+
+	meta {
+		author: "Lily Karim (WDLization by Ash O'Farrell)"
+	}
+
+	output {
+		File mask_file = basename_bam+"_below_"+min_coverage_per_site+"x_coverage.bedgraph"  # !StringCoercion
+		File? diff = basename_vcf+".diff"
+		File? report = basename_vcf+".report"
+		File? histogram = "histogram.txt"
+		String errorcode = read_string("ERROR")
+	}
+}
+
 task make_mask_and_diff {
 	# This is the version currently used by myco!
 	#

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -183,17 +183,19 @@ task make_mask_and_diff_and_process_metadata {
 	valid_metadata_dict = dict()
 	for keys, values in metadata_dict.items():
 		if keys == "UNDEFINED" and values == "UNDEFINED":
+			print("Keys and values is undefined, dropping")
 			continue
 		elif keys == "UNDEFINED": # and values does not
 			print(f"WARNING: Got metadata value {value} with undefined key")
 			continue
 		else:
-			print(f"{key}: {value}")
-			valid_metadata_dict[key] = value
+			# it's okay if value is undefined
+			print(f"{keys}: {values}")
+			valid_metadata_dict[keys] = values
 	
 	# turn this into something WDL can use
 	header = "sample\t" + "\t".join(valid_metadata_dict.keys())
-	body = "~{basename_vcf}\t" + "\t".join(valid_metadata_dict.keys())
+	body = "~{basename_vcf}\t" + "\t".join(valid_metadata_dict.values())
 	with open('header.txt', 'w') as f:
 		f.write(header)
 	with open('body.txt', 'w') as f:

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -122,6 +122,12 @@ task make_mask_and_diff_and_process_metadata {
 				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
 				echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
 				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
+				end=$(date +%s)
+				seconds=$(echo "$end - $start" | bc)
+				minutes=$(echo "$seconds" / 60 | bc)
+				echo "Finished in about $minutes minutes ($seconds sec))"
+				ls -lha
+				exit 0
 			fi
 		fi
 	fi

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -183,8 +183,8 @@ task make_mask_and_diff_and_process_metadata {
 			valid_metadata_dict[key] = value
 	
 	# turn this into something WDL can use
-	header = "sample\t" + "\t".join(valid_metadata.keys())
-	body = "~{basename_vcf}.diff\t" + "\t".join(valid_metadata.keys())
+	header = "sample\t" + "\t".join(valid_metadata_dict.keys())
+	body = "~{basename_vcf}.diff\t" + "\t".join(valid_metadata_dict.keys())
 	with open('header.txt', 'w') as f:
 		f.write(header)
 	with open('body.txt', 'w') as f:

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -23,6 +23,21 @@ task make_mask_and_diff_and_process_metadata {
 		File? tbmf
 		File vcf
 
+		# metadata key-value pairs; key is the name of the field, value is... value
+		# there are complex types that could in theory do this, but Cromwell's
+		# handling of optional values in complex types is buggy, so it's much safer
+		# to quasi-hardcode the number of metadata fields like this, even if it's cringe
+		String? a_key
+		String? a_value
+		String? b_key
+		String? b_value
+		String? c_key
+		String? c_value
+		String? d_key
+		String? d_value
+		String? e_key
+		String? e_value
+
 		# runtime attributes
 		Int addldisk = 10
 		Int cpu      = 8
@@ -135,7 +150,51 @@ task make_mask_and_diff_and_process_metadata {
 	fi
 
 	# this section only exectures if not failing
-			
+	python3 CODE <<
+	a_key =  "~{a_key}"
+	a_value = "~{a_value}"
+	b_key =  "~{b_key}"
+	b_value = "~{b_value}"
+	c_key =  "~{c_key}"
+	c_value = "~{c_value}"
+	d_key =  "~{d_key}"
+	d_value = "~{d_value}"
+	e_key =  "~{e_key}"
+	e_value = "~{e_value}"
+
+	valid_keys = []
+	for key in [a_key, b_key, c_key, d_key, e_key]:
+		if key == '' or key == ' ':
+			key = "UNDEFINED"
+		valid_keys.append(key)
+	valid_values = []
+	for value in [a_value, b_value, c_value, d_value, e_value]:
+		if value == '' or value == ' ':
+				value = "UNDEFINED"
+			valid_values.append(value)
+
+	metadata_dict = {a_key: a_value, b_key: b_value, c_key: c_value, d_key: d_value, e_key: e_value}
+	valid_metadata_dict = dict()
+	for keys, values in metadata_dict.items():
+		if keys == "UNDEFINED" and values == "UNDEFINED":
+			continue
+		elif keys == "UNDEFINED": # and values does not
+			print(f"WARNING: Got metadata value {value} with undefined key")
+			continue
+		else:
+			print(f"{key}: {value}")
+			valid_metadata_dict[key] = value
+	
+	# turn this into something WDL can use
+	header = "sample\t" + "\t".join(valid_metadata.keys())
+	body = "~{basename_vcf}.diff\t" + "\t".join(valid_metadata.keys())
+	with open('header.txt', 'w') as f:
+		f.write(header)
+	with open('body.txt', 'w') as f:
+		f.write(body)
+	CODE
+
+	# how long did this take?
 	end=$(date +%s)
 	seconds=$(echo "$end - $start" | bc)
 	minutes=$(echo "$seconds" / 60 | bc)
@@ -161,6 +220,8 @@ task make_mask_and_diff_and_process_metadata {
 		File? diff = basename_vcf+".diff"
 		File? report = basename_vcf+".report"
 		File? histogram = "histogram.txt"
+		String? metadata_fields = read_string("header.txt")
+		String? metadata_values = read_string("body.txt")
 		String errorcode = read_string("ERROR")
 	}
 }

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -161,14 +161,22 @@ task make_mask_and_diff_and_process_metadata {
 
 	valid_keys = []
 	for key in [a_key, b_key, c_key, d_key, e_key]:
+		print(key)
 		if key == '' or key == ' ':
+			print(f"key [{key}] effectively is undefined")
 			key = "UNDEFINED"
+		print(f"adding {key} to valid_keys")
 		valid_keys.append(key.strip("'").strip('"'))
+		print(f"valid_keys: {valid_keys}")
 	valid_values = []
 	for value in [a_value, b_value, c_value, d_value, e_value]:
+		print(value)
 		if value == '' or value == ' ':
+			print(f"value [{value}] effectively is undefined")
 			value = "UNDEFINED"
+		print(f"adding {value} to valid_values")
 		valid_values.append(value.strip("'").strip('"'))
+		print(f"valid_values: {valid_values}")
 
 	metadata_dict = {a_key: a_value, b_key: b_value, c_key: c_value, d_key: d_value, e_key: e_value}
 	valid_metadata_dict = dict()

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -104,6 +104,7 @@ task make_mask_and_diff_and_process_metadata {
 		# not using scientific notation
 		else
 			percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
+			maximium_percent_low_coverage=$(echo "~{max_ratio_low_coverage_sites_per_sample}*100" | bc)
 			echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
 			
 			# piping an inequality to `bc` will return 0 if false, 1 if true
@@ -121,7 +122,8 @@ task make_mask_and_diff_and_process_metadata {
 				fi
 				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
 				echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
-				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
+				echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE_(MAX_"~{maximium_percent_low_coverage}"_PCT) >> ERROR
+
 				end=$(date +%s)
 				seconds=$(echo "$end - $start" | bc)
 				minutes=$(echo "$seconds" / 60 | bc)
@@ -131,6 +133,8 @@ task make_mask_and_diff_and_process_metadata {
 			fi
 		fi
 	fi
+
+	# this section only exectures if not failing
 			
 	end=$(date +%s)
 	seconds=$(echo "$end - $start" | bc)

--- a/vcf_to_diff.wdl
+++ b/vcf_to_diff.wdl
@@ -13,7 +13,7 @@ task make_mask_and_diff_and_process_metadata {
 	# so you'd have one two-line TSV file per sample, and then you'd have to localize all of 
 	# those thousands of TSV files into a downstream task, and then concatenate them.
 	#
-	# I don't love this workaround, but it seems to be the best option for now.
+	# There are alternatives to doing this, so this is currently not in the main version of myco.
 	input {
 		File bam
 		Boolean force_diff = false
@@ -339,33 +339,33 @@ task make_mask_and_diff {
 		echo "$this_files_info" > temp
 		amount_low_coverage=$(cut -f2 temp)
 		
-		# account for very tiny numbers
+		# account for very tiny numbers (very big numbers should be impossible)
 		if [[ "$amount_low_coverage" == *"e"* ]]
 		then
 			echo "Scientific notation detected, so it's likely this sample is very much passing."
 			echo "PASS" >> ERROR
-			exit 0
-		fi
-		
-		percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
-		echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
-		
-		# piping an inequality to `bc` will return 0 if false, 1 if true
-		is_bigger=$(echo "$amount_low_coverage>~{max_ratio_low_coverage_sites_per_sample}" | bc)
-		if [[ $is_bigger == 0 ]]
-		then
-			# amount of low coverage is BELOW the removal threshold: sample passes
-			echo "PASS" >> ERROR
-	
 		else
-			# amount of low coverage is ABOVE the removal threshold: sample fails
-			if [[ "~{force_diff}" == "false" ]]
+			percent_low_coverage=$(echo "$amount_low_coverage"*100 | bc)
+			maximium_percent_low_coverage=$(echo "~{max_ratio_low_coverage_sites_per_sample}*100" | bc)
+			echo "$percent_low_coverage percent of ~{basename_vcf} is below ~{min_coverage_per_site}x coverage."
+			
+			# piping an inequality to `bc` will return 0 if false, 1 if true
+			is_bigger=$(echo "$amount_low_coverage>~{max_ratio_low_coverage_sites_per_sample}" | bc)
+			if [[ $is_bigger == 0 ]]
 			then
-				rm "~{basename_vcf}.diff"
+				# amount of low coverage is BELOW the removal threshold: sample passes
+				echo "PASS" >> ERROR
+		
+			else
+				# amount of low coverage is ABOVE the removal threshold: sample fails
+				if [[ "~{force_diff}" == "false" ]]
+				then
+					rm "~{basename_vcf}.diff"
+				fi
+				pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
+				echo FAILURE - "$pretty_percent""%" is above "~{min_coverage_per_site}""%"
+				VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE_"("MAX_"$maximium_percent_low_coverage"_PCT")" >> ERROR
 			fi
-			pretty_percent=$(printf "%0.2f" "$percent_low_coverage")
-			echo FAILURE - "$pretty_percent""%" is above "~{max_ratio_low_coverage_sites_per_sample}""%" cutoff
-			echo VCF2DIFF_"$pretty_percent"_PCT_BELOW_"~{min_coverage_per_site}"x_COVERAGE >> ERROR
 		fi
 	fi
 			


### PR DESCRIPTION
## Why?
We need Tree Nine to be able to take in metadata from arbitrary columns on the data table. However, Terra drops null values at runtime, so we can't actually align samples with their metadata:

Array[File] passing_samples = [foo.diff, bar.diff, bizz.diff]
Arrray[String] metadata = [1, 2, 3, 4]

The easiest way to handle this is to process the metadata upstream in myco, since myco knows what samples are failing and it can take in the same metadata columns Tree Nine does. The idea is that we have the final task, if passing, copy metadata to a new column. This would allow the table to be perfectly aligned (assuming 3 was associated with a sample that was failing):

Array[File] passing_samples = [foo.diff, bar.diff, bizz.diff]
Arrray[String] passing_metadata = [1, 2, 4]

## Why not?
A different approach is already used in myco for TBProfiler outputs. That method uses WDL coercion, which currently works but is undocumented off-spec behavior and could break in future versions of Cromwell.

| scenario      	| WDL coerce 	| final task output 	|
|---------------	|------------	|-------------------	|
| fail decontam 	| ❌          	| ❌                 	|
| fail tbprof   	| depends?   	| ❌                 	|
| fail VCF      	| yes?       	| ❌                 	|
| fail diff     	| yes?       	| ❌                 	|
| pass          	| yes        	| yes               	|

The advantage of WDL coerce as it's currently implemented is the fact metadata could get written to a failing column doesn't actually matter, since the WDL coerce version writes the sample name in the same string. So in Tree Nine, it doesn't matter if number of samples != number of metadata fields, since we can just use slap the metadata together into a TSV and then filter based on that. In fact I'm not sure we even need to filter, matUtils should just skip samples that aren't on the tree, I would hope...

## Deciding factors
* Is it important someone visually looking at the table immediately knows if a sample is pass or fail based on its metadata columns? --> Probably not since there is also a pass/fail status column

WDL coerce requires we trust:
* Arrays are always ordered (this is on the WDL spec so this should be safe)
* No one touches the data table in a way we don't expect
* Samples are never removed

Final task output requires we trust:
...well, actually none of these, because I could change it further to output the sample name in the string too, so it keeps the advantages of WDL coerce without the drawbacks...